### PR TITLE
add-release.sh: Fix mapfile invocation

### DIFF
--- a/scripts/add-release.sh
+++ b/scripts/add-release.sh
@@ -103,7 +103,7 @@ get_append_line () {
     local current="$1" line r releases smallest
 
     # Get all releases by parsing Makefile.releases
-    mapfile releases < <(sed -n 's/^# Cilium v\([0-9.]*\)$/\1/p' Makefile.releases)
+    mapfile -t releases < <(sed -n 's/^# Cilium v\([0-9.]*\)$/\1/p' Makefile.releases)
     for r in "${releases[@]}"; do
         # Compare release numbers by sorting them and checking whether our new
         # entry is the smallest


### PR DESCRIPTION
"mapfile" was added in response to shellcheck's complaints in CI, and the change was not tested well enough. As it turns out, the current invocation pulls the newline characters at the end of version numbers into the array, making the version check fail.

We just miss the `-t` flag to automatically trim these newline characters. Let's fix it.
