### PR TITLE
Update GitHub Docker Actions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -40,18 +40,19 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 #v3.0.0
       - name: Login to Quay.io
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d #v3.0.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_ISOVALENT_DEV_USERNAME }}
           password: ${{ secrets.QUAY_ISOVALENT_DEV_PASSWORD }}
       - name: Push to Quay.io
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 #v5.0.0
         with:
+          provenance: false
           context: ./operator/cilium.${{ env.VERSION }}/
           push: true
           tags: quay.io/isovalent-dev/cilium-olm-ci:${{ env.VERSION }}-${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,18 +31,19 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 #v3.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 #v3.0.0
       - name: Login to scan.connect.redhat.com
-        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d #v3.0.0
         with:
           registry: quay.io
           username: redhat-isv-containers+5fbe31ec8b7d4976604cbde0-robot
           password: ${{ secrets.RHCP_OLM_REGISTRY_PASSWORD }}
       - name: Push to Quay.io
-        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 #v5.0.0
         with:
+          provenance: false
           context: ./operator/cilium.v${{ github.event.inputs.version }}/
           push: true
           tags: quay.io/redhat-isv-containers/5fbe31ec8b7d4976604cbde0:${{ env.OLM_TAG }}


### PR DESCRIPTION
This change allows us to set provenance
to false and build images properly for
Red Hat repos.